### PR TITLE
feat: add remark-mdxld dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,14 @@
   "bugs": {
     "url": "https://github.com/ai-primitives/next-mdxld/issues"
   },
+  "dependencies": {
+    "mdxld": "^0.1.0",
+    "remark-mdxld": "^0.1.0",
+    "@mdx-js/loader": "^3.0.0",
+    "@mdx-js/react": "^3.0.0",
+    "remark-gfm": "^4.0.0",
+    "remark-mdx-frontmatter": "^4.0.0"
+  },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
     "@semantic-release/commit-analyzer": "^13.0.0",


### PR DESCRIPTION
Add remark-mdxld and required MDX dependencies to next-mdxld package.

Changes:
- Add remark-mdxld as a direct dependency
- Add @mdx-js/loader and @mdx-js/react for MDX processing
- Add remark plugins for GFM and frontmatter support

Link to Devin run: https://app.devin.ai/sessions/cdd420a108484c398e51b71d248cd883