### PR TITLE
feat: generateMetadata from frontmatter

### DIFF
--- a/examples/blog/app/[[...mdxPath]]/page.tsx
+++ b/examples/blog/app/[[...mdxPath]]/page.tsx
@@ -1,6 +1,18 @@
-import { createMDXPage } from 'next-mdxld'
+import { createMDXPage, mapFrontmatterToMetadata } from 'next-mdxld'
 import { join } from 'path'
+import type { Metadata } from 'next'
 
-export default createMDXPage({
+const mdxPage = createMDXPage({
   contentDir: join(process.cwd(), 'content')
 })
+
+export const generateMetadata = async ({ params }): Promise<Metadata> => {
+  const { getMDXData } = mdxPage
+  const data = await getMDXData(params)
+  if (!data?.frontmatter) {
+    return {}
+  }
+  return mapFrontmatterToMetadata(data.frontmatter)
+}
+
+export default mdxPage

--- a/examples/blog/app/[[...mdxPath]]/page.tsx
+++ b/examples/blog/app/[[...mdxPath]]/page.tsx
@@ -1,18 +1,12 @@
-import { createMDXPage, mapFrontmatterToMetadata } from 'next-mdxld'
+import { createMDXPage, generateMetadata as generateMDXMetadata } from 'next-mdxld'
 import { join } from 'path'
-import type { Metadata } from 'next'
 
+const contentDir = join(process.cwd(), 'content')
 const mdxPage = createMDXPage({
-  contentDir: join(process.cwd(), 'content')
+  contentDir
 })
 
-export const generateMetadata = async ({ params }): Promise<Metadata> => {
-  const { getMDXData } = mdxPage
-  const data = await getMDXData(params)
-  if (!data?.frontmatter) {
-    return {}
-  }
-  return mapFrontmatterToMetadata(data.frontmatter)
-}
+// Configure generateMetadata with contentDir
+export const generateMetadata = ({ params }) => generateMDXMetadata({ params }, contentDir)
 
 export default mdxPage

--- a/examples/blog/content/hello-world.mdx
+++ b/examples/blog/content/hello-world.mdx
@@ -1,8 +1,15 @@
 ---
-type: blog
+$type: https://schema.org/BlogPosting
 title: Getting Started with next-mdxld
+description: A comprehensive guide to using next-mdxld for building content-driven Next.js applications with full metadata support
 author: John Doe
 datePublished: 2024-01-15
+image: /blog/hello-world/cover.jpg
+keywords:
+  - next.js
+  - mdx
+  - metadata
+  - content management
 ---
 
 # Welcome to next-mdxld

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,13 @@ import type { WebpackConfigContext } from 'next/dist/server/config-shared'
 import remarkMdxld from './remark-mdxld'
 import remarkGfm from 'remark-gfm'
 import remarkFrontmatter from 'remark-frontmatter'
-import { createMDXPage, type Frontmatter, type MDXPageComponent } from './page.js'
+import {
+  createMDXPage,
+  generateMetadata,
+  type Frontmatter,
+  type MDXPageComponent,
+  type MDXPageParams
+} from './page.js'
 import { default as BlogLayout } from './layouts/BlogLayout.js'
 import { default as BlogPosting } from './components/BlogPosting.js'
 
@@ -60,6 +66,6 @@ const withMdxld = (nextConfig: NextConfig = {}) => {
 }
 
 export default withMdxld
-export { createMDXPage, remarkMdxld }
-export type { Frontmatter, MDXPageComponent }
+export { createMDXPage, remarkMdxld, generateMetadata }
+export type { Frontmatter, MDXPageComponent, MDXPageParams }
 export { BlogLayout, BlogPosting }


### PR DESCRIPTION
Implements mapping of frontmatter to Next.js metadata + usage example.

Changes:
- Add mapFrontmatterToMetadata function for metadata mapping
- Implement generateMetadata in dynamic pages
- Update blog example with comprehensive metadata
- Support title, description, openGraph, and Twitter cards

Link to Devin run: https://app.devin.ai/sessions/626cf131345a4dbeb897567fc656137d